### PR TITLE
 Changes to be committed:

### DIFF
--- a/_legacy_docker/how-to-guides/deployment/building-your-service.md
+++ b/_legacy_docker/how-to-guides/deployment/building-your-service.md
@@ -177,23 +177,6 @@ services:
 
 ```
 
-If you are using [Google Container Registry](https://cloud.google.com/container-registry/docs/) for your image repository, you will use the following URL format:
-
-```
-
-services:
-    <service_name>:
-        image: gcr.io/<project_id>/<namespace>/<image_name>:/<tag>
-
-```
-
-When you [specify the Google Container Registy as a Docker image repo](https://app.cloud66.com/image_repositories) you need choice `I'm using a different provider or my own custom repo` and use the following settings:
-
-*   Custom Repo provider URL = https://gcr.io
-*   Username for provider = oauth2accesstoken
-*   Password for provider = (output of the commmand `$ gcloud auth print-access-token`)
-*   Email address for provider = fake@fake.com
-
 
 ### Using Habitus for builds
 

--- a/_legacy_docker/how-to-guides/deployment/image-repository.md
+++ b/_legacy_docker/how-to-guides/deployment/image-repository.md
@@ -37,25 +37,9 @@ quay.io/<namespace>/<image_name>:<tag>
 
 ```
 
-If you are using [Google Container Registry](https://cloud.google.com/container-registry/docs/) for your image repository, you will use the following URL format:
-
-```
-
-gcr.io/<project_id>/<namespace>/<image_name>:<tag>
-
-```
-
-
-
 
 ### How To Add Docker Image Repository
 
 You need to go to _Account_ --> _Keys & External Services_ --> _Docker Image Repo_  and click on _ADD A PROVIDER_ or click on __+__ if you already have one and want to add a second one.
 
-When you [specify the Google Container Registy as a Docker image repo](https://app.cloud66.com/image_repositories) you need to  choose `I'm using a different provider or my own custom repo` and use the following settings:
-
-*   Custom Repo provider URL = https://gcr.io
-*   Username for provider = oauth2accesstoken
-*   Password for provider = (output of the commmand `$ gcloud auth print-access-token`)
-*   Email address for provider = fake@fake.com
 

--- a/_maestro/how-to-guides/deployment/image-repository.md
+++ b/_maestro/how-to-guides/deployment/image-repository.md
@@ -37,25 +37,10 @@ quay.io/<namespace>/<image_name>:<tag>
 
 ```
 
-If you are using [Google Container Registry](https://cloud.google.com/container-registry/docs/) for your image repository, you will use the following URL format:
-
-```
-
-gcr.io/<project_id>/<namespace>/<image_name>:<tag>
-
-```
-
-
 
 
 ### How To Add Docker Image Repository
 
 You need to go to _Account_ --> _Keys & External Services_ --> _Docker Image Repo_  and click on _ADD A PROVIDER_ or click on __+__ if you already have one and want to add a second one.
 
-When you [specify the Google Container Registy as a Docker image repo](https://app.cloud66.com/image_repositories) you need to  choose `I'm using a different provider or my own custom repo` and use the following settings:
-
-*   Custom Repo provider URL = https://gcr.io
-*   Username for provider = oauth2accesstoken
-*   Password for provider = (output of the commmand `$ gcloud auth print-access-token`)
-*   Email address for provider = fake@fake.com
 

--- a/_skycap/how-to-guides/building/building-your-service.md
+++ b/_skycap/how-to-guides/building/building-your-service.md
@@ -180,21 +180,6 @@ services:
         image: quay.io/<namespace>/<image_name>:/<tag>
 ```
 
-If you are using [Google Container Registry](https://cloud.google.com/container-registry/docs/) for your image repository, you will use the following URL format:
-
-```
-services:
-    <service_name>:
-        image: gcr.io/<project_id>/<namespace>/<image_name>:/<tag>
-```
-
-When you [specify the Google Container Registy as a Docker image repo](https://app.cloud66.com/image_repositories) you need choice `I'm using a different provider or my own custom repo` and use the following settings:
-
-*   Custom Repo provider URL = https://gcr.io
-*   Username for provider = oauth2accesstoken
-*   Password for provider = (output of the commmand `$ gcloud auth print-access-token`)
-*   Email address for provider = fake@fake.com
-
 
 ### Using Habitus for builds
 


### PR DESCRIPTION
	modified:   _legacy_docker/how-to-guides/deployment/building-your-service.md
	modified:   _legacy_docker/how-to-guides/deployment/image-repository.md
	modified:   _maestro/how-to-guides/deployment/image-repository.md
	modified:   _skycap/how-to-guides/building/building-your-service.md

Removed the help page for gcr.io docker image repository from our help
pages, as we don't support them anymore due to a change on Gcloud. there
is a ticket created for that in Central issues so that it will be
implemented later. For the time being to reduce the workload on our side
I've removed it.